### PR TITLE
PocketMine-MP API 4.x.x Update

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -1,9 +1,7 @@
 --- # Poggit-CI Manifest. Open the CI at https://poggit.pmmp.io/ci/EvolSoft/CustomAlerts
 branches:
-- master
+- PMMP-4
 projects:
   CustomAlerts:
     path: CustomAlerts/
-  CustomAlertsExample:
-    path: CustomAlertsExample/
 ...

--- a/CustomAlerts/plugin.yml
+++ b/CustomAlerts/plugin.yml
@@ -1,11 +1,11 @@
 name: CustomAlerts
 main: CustomAlerts\CustomAlerts
-version: 2.1
-api: [3.0.0]
+version: 2.4
+api: [4.0.0]
 load: STARTUP
-author: EvolSoft
+author: [EvolSoft, KanekiLeChomeur]
 description: Customize or hide alerts (join/leave messages, whitelist messages, outdated server/client messages, etc...) plugin
-website: https://www.evolsoft.tk
+website: https://github.com/KanekiLeChomeur/CustomAlerts/
 
 commands:
   customalerts:
@@ -17,12 +17,12 @@ permissions:
     default: op
     description: CustomAlerts permission tree.
     children:
-      customalerts.help:
-        default: op
-        description: let player read CustomAlerts commands help.
-      customalerts.info:
-        default: op
-        description: Let player read info about CustomAlerts.
-      customalerts.reload:
-        default: op
-        description: Let player reload CustomAlerts configuration.
+  customalerts.help:
+    default: op
+    description: let player read CustomAlerts commands help.
+  customalerts.info:
+    default: op
+    description: Let player read info about CustomAlerts.
+  customalerts.reload:
+    default: op
+    description: Let player reload CustomAlerts configuration.

--- a/CustomAlerts/src/CustomAlerts/Commands/Commands.php
+++ b/CustomAlerts/src/CustomAlerts/Commands/Commands.php
@@ -18,7 +18,8 @@ use pocketmine\utils\TextFormat;
 
 use CustomAlerts\CustomAlerts;
 
-class Commands extends PluginCommand implements CommandExecutor {
+class Commands implements CommandExecutor{
+
 
 	public function __construct(CustomAlerts $plugin){
        $this->plugin = $plugin;
@@ -32,7 +33,7 @@ class Commands extends PluginCommand implements CommandExecutor {
 			        goto help;
 			    case "info":
 			        if($sender->hasPermission("customalerts.info")){
-			            $sender->sendMessage(TextFormat::colorize(CustomAlerts::PREFIX . "&aCustomAlerts &dv" . $this->plugin->getDescription()->getVersion() . "&a developed by &dEvolSoft"));
+			            $sender->sendMessage(TextFormat::colorize(CustomAlerts::PREFIX . "&aCustomAlerts &dv" . $this->plugin->getDescription()->getVersion() . "&a developed by &dEvolSoft §r§aand updated by §dKanekiLeChomeur "));
 			            $sender->sendMessage(TextFormat::colorize(CustomAlerts::PREFIX . "&aWebsite &d" . $this->plugin->getDescription()->getWebsite()));
 			            break;
 			        }

--- a/CustomAlerts/src/CustomAlerts/Commands/Commands.php
+++ b/CustomAlerts/src/CustomAlerts/Commands/Commands.php
@@ -20,8 +20,9 @@ use CustomAlerts\CustomAlerts;
 
 class Commands implements CommandExecutor{
 
-
-	public function __construct(CustomAlerts $plugin){
+    private $plugin;
+	
+    public function __construct(CustomAlerts $plugin){
        $this->plugin = $plugin;
     }
     

--- a/CustomAlerts/src/CustomAlerts/CustomAlerts.php
+++ b/CustomAlerts/src/CustomAlerts/CustomAlerts.php
@@ -21,6 +21,9 @@ use pocketmine\utils\TextFormat;
 use CustomAlerts\Commands\Commands;
 use CustomAlerts\Events\CustomAlertsMotdUpdateEvent;
 use pocketmine\command\PluginCommand;
+use pocketmine\entity\projectile\Projectile;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\event\entity\ProjectileHitEntityEvent;
 use pocketmine\player\Player as PlayerPlayer;
 use pocketmine\player\PlayerInfo;
 use pocketmine\world\World;
@@ -344,7 +347,7 @@ class CustomAlerts extends PluginBase {
      *
      * @return bool
      */
-    public function isDeathMessageCustom(EntityDamageEvent $cause = null){
+    public function isDeathMessageCustom(?EntityDamageEvent $cause = null){
         if(!$cause){
             return $this->cfg["Death"]["custom"];
         }
@@ -453,19 +456,26 @@ class CustomAlerts extends PluginBase {
                     break;
                 case EntityDamageEvent::CAUSE_ENTITY_ATTACK:
                     $message = $this->cfg["Death"]["kill-message"]["message"];
-                    $killer = $cause->getDamager();
-                    if($killer instanceof Living){
-                        $array["KILLER"] = $killer->getName();
-                        break;
+                    if($cause instanceof EntityDamageByEntityEvent){
+                        $killer = $cause->getDamager();
+                        if($killer instanceof Living){
+                            $array["KILLER"] = $killer->getName();
+                            break;
+                        }
                     }
                     $array["KILLER"] = "Unknown";
                     break;
                 case EntityDamageEvent::CAUSE_PROJECTILE:
                     $message = $this->cfg["Death"]["death-projectile-message"]["message"];
-                    $killer = $cause->getDamager();
-                    if($killer instanceof Living){
-                        $array["KILLER"] = $killer->getName();
-                        break;
+                    if($cause instanceof ProjectileHitEntityEvent){
+                        $projectile = $cause->getEntity();
+                        if($projectile instanceof Projectile){
+                            $killer = $projectile->getOwningEntity();
+                            if($killer instanceof Living){
+                                $array["KILLER"] = $killer->getName();
+                                break;
+                            }
+                        }
                     }
                     $array["KILLER"] = "Unknown";
                     break;

--- a/CustomAlerts/src/CustomAlerts/CustomAlerts.php
+++ b/CustomAlerts/src/CustomAlerts/CustomAlerts.php
@@ -24,6 +24,7 @@ use pocketmine\command\PluginCommand;
 use pocketmine\entity\projectile\Projectile;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\ProjectileHitEntityEvent;
+use pocketmine\event\entity\ProjectileHitEvent;
 use pocketmine\player\Player as PlayerPlayer;
 use pocketmine\player\PlayerInfo;
 use pocketmine\world\World;
@@ -344,6 +345,7 @@ class CustomAlerts extends PluginBase {
      * Check if death messages are custom
      * 
      *
+     * @return bool
      */
     public function isDeathMessageCustom(?EntityDamageEvent $cause = null){
         if(!$cause){
@@ -465,13 +467,15 @@ class CustomAlerts extends PluginBase {
                     break;
                 case EntityDamageEvent::CAUSE_PROJECTILE:
                     $message = $this->cfg["Death"]["death-projectile-message"]["message"];
-                    if($cause instanceof ProjectileHitEntityEvent){
-                        $projectile = $cause->getEntity();
-                        if($projectile instanceof Projectile){
-                            $killer = $projectile->getOwningEntity();
-                            if($killer instanceof Living){
-                                $array["KILLER"] = $killer->getName();
-                                break;
+                    if($cause instanceof ProjectileHitEvent){
+                        if($cause instanceof ProjectileHitEntityEvent){
+                            $projectile = $cause->getEntity();
+                            if($projectile instanceof Projectile){
+                                $killer = $projectile->getOwningEntity();
+                                if($killer instanceof Living){
+                                    $array["KILLER"] = $killer->getName();
+                                    break;
+                                }
                             }
                         }
                     }

--- a/CustomAlerts/src/CustomAlerts/CustomAlerts.php
+++ b/CustomAlerts/src/CustomAlerts/CustomAlerts.php
@@ -343,7 +343,6 @@ class CustomAlerts extends PluginBase {
     /**
      * Check if death messages are custom
      * 
-     * @param ?EntityDamageEvent $cause
      *
      * @return bool
      */

--- a/CustomAlerts/src/CustomAlerts/CustomAlerts.php
+++ b/CustomAlerts/src/CustomAlerts/CustomAlerts.php
@@ -24,7 +24,6 @@ use pocketmine\command\PluginCommand;
 use pocketmine\entity\projectile\Projectile;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\ProjectileHitEntityEvent;
-use pocketmine\event\entity\ProjectileHitEvent;
 use pocketmine\player\Player as PlayerPlayer;
 use pocketmine\player\PlayerInfo;
 use pocketmine\world\World;
@@ -467,15 +466,13 @@ class CustomAlerts extends PluginBase {
                     break;
                 case EntityDamageEvent::CAUSE_PROJECTILE:
                     $message = $this->cfg["Death"]["death-projectile-message"]["message"];
-                    if($cause instanceof ProjectileHitEvent){
-                        if($cause instanceof ProjectileHitEntityEvent){
-                            $projectile = $cause->getEntity();
-                            if($projectile instanceof Projectile){
-                                $killer = $projectile->getOwningEntity();
-                                if($killer instanceof Living){
-                                    $array["KILLER"] = $killer->getName();
-                                    break;
-                                }
+                    if($cause instanceof ProjectileHitEntityEvent){
+                        $projectile = $cause->getEntity();
+                        if($projectile instanceof Projectile){
+                            $killer = $projectile->getOwningEntity();
+                            if($killer instanceof Living){
+                                $array["KILLER"] = $killer->getName();
+                                break;
                             }
                         }
                     }

--- a/CustomAlerts/src/CustomAlerts/CustomAlerts.php
+++ b/CustomAlerts/src/CustomAlerts/CustomAlerts.php
@@ -343,7 +343,7 @@ class CustomAlerts extends PluginBase {
     /**
      * Check if death messages are custom
      * 
-     * @param EntityDeathEvent $cause
+     * @param EntityDamageEvent $cause
      *
      * @return bool
      */

--- a/CustomAlerts/src/CustomAlerts/CustomAlerts.php
+++ b/CustomAlerts/src/CustomAlerts/CustomAlerts.php
@@ -344,7 +344,6 @@ class CustomAlerts extends PluginBase {
      * Check if death messages are custom
      * 
      *
-     * @return bool
      */
     public function isDeathMessageCustom(?EntityDamageEvent $cause = null){
         if(!$cause){

--- a/CustomAlerts/src/CustomAlerts/CustomAlerts.php
+++ b/CustomAlerts/src/CustomAlerts/CustomAlerts.php
@@ -141,8 +141,6 @@ class CustomAlerts extends PluginBase {
     
     /**
      * Get outdated client message
-     * 
-     * @param Player
      *
      * @return string
      */
@@ -165,7 +163,6 @@ class CustomAlerts extends PluginBase {
     /**
      * Get outdated server message
      * 
-     * @param Player
      *
      * @return string
      */
@@ -188,7 +185,7 @@ class CustomAlerts extends PluginBase {
     /**
      * Get whitelist message
      * 
-     * @param Player
+     * @param PlayerInfo
      *
      * @return string
      */

--- a/CustomAlerts/src/CustomAlerts/CustomAlerts.php
+++ b/CustomAlerts/src/CustomAlerts/CustomAlerts.php
@@ -343,7 +343,7 @@ class CustomAlerts extends PluginBase {
     /**
      * Check if death messages are custom
      * 
-     * @param EntityDamageEvent $cause
+     * @param ?EntityDamageEvent $cause
      *
      * @return bool
      */

--- a/CustomAlerts/src/CustomAlerts/CustomAlerts.php
+++ b/CustomAlerts/src/CustomAlerts/CustomAlerts.php
@@ -184,14 +184,11 @@ class CustomAlerts extends PluginBase {
     
     /**
      * Get whitelist message
-     * 
-     * @param PlayerInfo
      *
      * @return string
      */
-    public function getWhitelistMessage(PlayerInfo $player){
+    public function getWhitelistMessage(){
         return TextFormat::colorize($this->replaceVars($this->cfg["WhitelistedServer"]["message"], array(
-            "PLAYER" => $player->getUsername(),
             "MAXPLAYERS" => $this->getServer()->getMaxPlayers(),
             "TOTALPLAYERS" => count($this->getServer()->getOnlinePlayers()),
             "TIME" => date($this->cfg["datetime-format"]))));

--- a/CustomAlerts/src/CustomAlerts/Events/CustomAlertsDeathEvent.php
+++ b/CustomAlerts/src/CustomAlerts/Events/CustomAlertsDeathEvent.php
@@ -11,7 +11,7 @@
 namespace CustomAlerts\Events;
 
 use pocketmine\event\entity\EntityDamageEvent;
-use pocketmine\Player;
+use pocketmine\player\Player;
 
 class CustomAlertsDeathEvent extends CustomAlertsEvent {
 	

--- a/CustomAlerts/src/CustomAlerts/Events/CustomAlertsFullServerKickEvent.php
+++ b/CustomAlerts/src/CustomAlerts/Events/CustomAlertsFullServerKickEvent.php
@@ -10,28 +10,29 @@
 
 namespace CustomAlerts\Events;
 
-use pocketmine\Player;
+use pocketmine\player\Player;
+use pocketmine\player\PlayerInfo;
 
 class CustomAlertsFullServerKickEvent extends CustomAlertsEvent {
 	
 	public static $handlerList = null;
 	
-	/** @var Player $player */
+	/** @var PlayerInfo $player */
 	private $player;
 	
 	/**
-	 * @param Player $player
+	 * @param PlayerInfo $player
 	 */
-	public function __construct(Player $player){
+	public function __construct(PlayerInfo $player){
 		$this->player = $player;
 	}
 
 	/**
 	 * Get full server kick event player
 	 * 
-	 * @return Player
+	 * @return PlayerInfo
 	 */
-	public function getPlayer() : Player {
+	public function getPlayerInfo() : PlayerInfo {
 		return $this->player;
 	}
 }

--- a/CustomAlerts/src/CustomAlerts/Events/CustomAlertsJoinEvent.php
+++ b/CustomAlerts/src/CustomAlerts/Events/CustomAlertsJoinEvent.php
@@ -10,7 +10,7 @@
 
 namespace CustomAlerts\Events;
 
-use pocketmine\Player;
+use pocketmine\player\Player;
 
 class CustomAlertsJoinEvent extends CustomAlertsEvent {
 	

--- a/CustomAlerts/src/CustomAlerts/Events/CustomAlertsOutdatedClientKickEvent.php
+++ b/CustomAlerts/src/CustomAlerts/Events/CustomAlertsOutdatedClientKickEvent.php
@@ -10,28 +10,29 @@
 
 namespace CustomAlerts\Events;
 
-use pocketmine\Player;
+use pocketmine\network\mcpe\NetworkSession;
+use pocketmine\player\Player;
 
 class CustomAlertsOutdatedClientKickEvent extends CustomAlertsEvent {
 	
 	public static $handlerList = null;
 	
-	/** @var Player $player */
-	private $player;
+	/** @var NetworkSession $origin */
+	private $origin;
 	
 	/**
-	 * @param Player $player
+	 * @param NetworkSession $origin
 	 */
-	public function __construct(Player $player){
-		$this->player = $player;
+	public function __construct(NetworkSession $origin){
+		$this->origin = $origin;
 	}
 
 	/**
 	 * Get outdated client kick event player
 	 * 
-	 * @return Player
+	 * @return NetworkSession
 	 */
-	public function getPlayer() : Player {
-		return $this->player;
+	public function getOrigin() : ?NetworkSession {
+		return $this->origin;
 	}
 }

--- a/CustomAlerts/src/CustomAlerts/Events/CustomAlertsOutdatedClientKickEvent.php
+++ b/CustomAlerts/src/CustomAlerts/Events/CustomAlertsOutdatedClientKickEvent.php
@@ -23,7 +23,7 @@ class CustomAlertsOutdatedClientKickEvent extends CustomAlertsEvent {
 	/**
 	 * @param NetworkSession $origin
 	 */
-	public function __construct(NetworkSession $origin){
+	public function __construct(?NetworkSession $origin){
 		$this->origin = $origin;
 	}
 

--- a/CustomAlerts/src/CustomAlerts/Events/CustomAlertsOutdatedServerKickEvent.php
+++ b/CustomAlerts/src/CustomAlerts/Events/CustomAlertsOutdatedServerKickEvent.php
@@ -23,7 +23,7 @@ class CustomAlertsOutdatedServerKickEvent extends CustomAlertsEvent {
 	/**
 	 * @param NetworkSession $origin
 	 */
-	public function __construct(NetworkSession $origin){
+	public function __construct(?NetworkSession $origin){
 		$this->origin = $origin;
 	}
 

--- a/CustomAlerts/src/CustomAlerts/Events/CustomAlertsOutdatedServerKickEvent.php
+++ b/CustomAlerts/src/CustomAlerts/Events/CustomAlertsOutdatedServerKickEvent.php
@@ -10,28 +10,29 @@
 
 namespace CustomAlerts\Events;
 
-use pocketmine\Player;
+use pocketmine\player\Player;
+use pocketmine\network\mcpe\NetworkSession;
 
 class CustomAlertsOutdatedServerKickEvent extends CustomAlertsEvent {
 	
 	public static $handlerList = null;
 	
-	/** @var Player $player */
-	private $player;
+	/** @var NetworkSession $origin */
+	private $origin;
 	
 	/**
-	 * @param Player $player
+	 * @param NetworkSession $origin
 	 */
-	public function __construct(Player $player){
-		$this->player = $player;
+	public function __construct(NetworkSession $origin){
+		$this->origin = $origin;
 	}
 
 	/**
 	 * Get outdated server kick event player
 	 * 
-	 * @return Player
+	 * @return NetworkSession
 	 */
-	public function getPlayer() : Player {
-		return $this->player;
+	public function getOrigin() : ?NetworkSession {
+		return $this->origin;
 	}
 }

--- a/CustomAlerts/src/CustomAlerts/Events/CustomAlertsQuitEvent.php
+++ b/CustomAlerts/src/CustomAlerts/Events/CustomAlertsQuitEvent.php
@@ -10,7 +10,7 @@
 
 namespace CustomAlerts\Events;
 
-use pocketmine\Player;
+use pocketmine\player\Player;
 
 class CustomAlertsQuitEvent extends CustomAlertsEvent {
 	

--- a/CustomAlerts/src/CustomAlerts/Events/CustomAlertsWhitelistKickEvent.php
+++ b/CustomAlerts/src/CustomAlerts/Events/CustomAlertsWhitelistKickEvent.php
@@ -10,28 +10,28 @@
 
 namespace CustomAlerts\Events;
 
-use pocketmine\Player;
+use pocketmine\player\PlayerInfo;
 
 class CustomAlertsWhitelistKickEvent extends CustomAlertsEvent {
 	
 	public static $handlerList = null;
 	
-	/** @var Player $player */
+	/** @var PlayerInfo $player */
 	private $player;
 	
 	/**
-	 * @param Player $player
+	 * @param PlayerInfo $player
 	 */
-	public function __construct(Player $player){
+	public function __construct(?PlayerInfo $player){
 		$this->player = $player;
 	}
 
 	/**
 	 * Get whitelist kick event player
 	 * 
-	 * @return Player
+	 * @return PlayerInfo
 	 */
-	public function getPlayer() : Player {
+	public function getPlayerInfo() : ?PlayerInfo {
 		return $this->player;
 	}
 }

--- a/CustomAlerts/src/CustomAlerts/Events/CustomAlertsWorldChangeEvent.php
+++ b/CustomAlerts/src/CustomAlerts/Events/CustomAlertsWorldChangeEvent.php
@@ -10,8 +10,8 @@
 
 namespace CustomAlerts\Events;
 
-use pocketmine\level\Level;
-use pocketmine\Player;
+use pocketmine\player\Player;
+use pocketmine\world\World;
 
 class CustomAlertsWorldChangeEvent extends CustomAlertsEvent {
 	
@@ -20,18 +20,18 @@ class CustomAlertsWorldChangeEvent extends CustomAlertsEvent {
 	/** @var Player $player */
 	private $player;
 	
-	/** @var Level $origin */
+	/** @var World $origin */
 	private $origin;
 	
-	/** @var Level $target */
+	/** @var World $target */
 	private $target;
 	
 	/**
 	 * @param Player $player
-	 * @param Level $origin
-	 * @param Level $target
+	 * @param World $origin
+	 * @param World $target
 	 */
-	public function __construct(Player $player, Level $origin, Level $target){
+	public function __construct(Player $player, World $origin, World $target){
 		$this->player = $player;
 		$this->origin = $origin;
 		$this->target = $target;
@@ -49,18 +49,18 @@ class CustomAlertsWorldChangeEvent extends CustomAlertsEvent {
 	/**
 	 * Get origin level
 	 *
-	 * @return Level
+	 * @return World
 	 */
-	public function getOrigin() : Level {
+	public function getOrigin() : World {
 		return $this->origin;
 	}
 	
 	/**
 	 * Get target level
 	 *
-	 * @return Level
+	 * @return World
 	 */
-	public function getTarget() : Level {
+	public function getTarget() : World {
 		return $this->target;
 	}
 }

--- a/CustomAlerts/src/CustomAlerts/MotdTask.php
+++ b/CustomAlerts/src/CustomAlerts/MotdTask.php
@@ -21,7 +21,7 @@ class MotdTask extends Task {
       $this->plugin = $plugin;
     }
     
-    public function onRun($tick){
+    public function onRun() : void{
         CustomAlerts::getAPI()->updateMotd();
     }
 


### PR DESCRIPTION
<h1>Update to PocketMine-MP API 4.x.x</h1>

<h2>What's new ?</h2>
<p>It's an Compatibility Update from <b>PocketMine-MP API 3.x.x</b> to <b>PocketMine-MP API 4.x.x</b></p> 
<p>Player's Name/Username has been removed from <b>Outdated Server/Client Kick Message</b> and <b>Witelist Kick Message</b> has been removed due to <b>PocketMine-MP API 4.x.x Update</b>

<p><b>CustomAlertsOutdatedClientKickEvent</b> and <b>CustomAlertsOutdatedServerKickEvent</b> has now <b>getPlayer()</b> function edited to <b>getOrigin()</b> that returns <b>NetworkSession</b> or <b> null</b></p>

<p><b>CustomAlertsWhitelistKickEvent</b> has now <b>getPlayer()</b> function edited to <b>getPlayerInfo()</b> that returns <b>PlayerInfo</b> or <b> null</b></p></p>